### PR TITLE
Some minor README fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,9 +119,9 @@ $ ./autogen.sh --enable-debug
 $ vagrant up hub
 $ vagrant ssh hub
 $ cd /northern.tech/cfengine/core
-$ ./configure && make && sudo make -j2 install
+$ make -j2 && sudo make install
 $ cd ../masterfiles
-$ ./configure && make && sudo make -j2 install
+$ make -j2 && sudo make install
 $ sudo su -
 # /var/cfengine/bin/cf-key
 # /var/cfengine/bin/cf-agent --bootstrap 192.168.100.90
@@ -132,7 +132,7 @@ $ sudo su -
 $ vagrant up client
 $ vagrant ssh client
 $ cd /northern.tech/cfengine/core
-$ ./configure && make && sudo make -j2 install
+$ make -j2 && sudo make install
 $ sudo su -
 # /var/cfengine/bin/cf-key
 # /var/cfengine/bin/cf-agent --bootstrap 192.168.100.90


### PR DESCRIPTION
`./autogen.sh` already did `./configure`, and it does not make sense to use `-j2` on `make install`, instead it should be used on `make`.